### PR TITLE
feat!: callback as argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,9 @@
 export interface TransformResult {
   code: string
 }
-export function localImport(extension: string): Plugin
+export function localImport(callback: (path: string) => string): Plugin
 export class Plugin {
   name: string
   transform(sourceCode: string): TransformResult
+  buildEnd(): void
 }

--- a/plugin.js
+++ b/plugin.js
@@ -8,6 +8,7 @@ function callContextBindHack(...args) {
   return {
     name: plugin.name,
     transform: plugin.transform.bind(plugin),
+    buildEnd: plugin.buildEnd.bind(plugin),
   };
 }
 

--- a/test/rollup-integration.test.js
+++ b/test/rollup-integration.test.js
@@ -1,5 +1,5 @@
 import { rmSync, writeFileSync } from "fs";
-import { afterAll, beforeAll, expect, test } from "vitest";
+import { afterAll, expect, test } from "vitest";
 import { rollup } from "rollup";
 
 import { localImport } from "../plugin";
@@ -94,7 +94,12 @@ test("ImportDeclaration, side-effect", async () => {
 });
 
 test("plugin has name", () => {
-  expect(localImport(".js")).toHaveProperty("name", "local-import");
+  const plugin = localImport(() => {});
+
+  expect(plugin).toHaveProperty("name", "local-import");
+
+  // Manual cleanup
+  plugin.buildEnd();
 });
 
 async function run(source) {
@@ -103,7 +108,11 @@ async function run(source) {
   const build = await rollup({
     input,
     external: () => true,
-    plugins: [localImport(".js")],
+    plugins: [
+      localImport((path) => {
+        return `${path}.js`;
+      }),
+    ],
   });
 
   const bundle = await build.write({ output });


### PR DESCRIPTION
Support passing callback as argument:

```ts
plugins: [localImport((path: String) => {
    return `${path}.js`;
});
```

Lifetime of `JsFunction` works when using `env.create_reference`: https://github.com/napi-rs/napi-rs/issues/1333#issuecomment-1272323387.
