### PR TITLE
feat(error-handling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "build:debug": "napi build --platform",
     "changelog": "npx conventional-changelog-cli -i CHANGELOG.md -p conventionalcommits -s -r 0",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "vitest run --reporter verbose",
+    "test:watch": "vitest --reporter verbose",
     "version": "napi version"
   },
   "devDependencies": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,14 @@ pub struct TransformResult {
 #[napi]
 pub struct Plugin {
     pub name: String,
-    callback: Ref<()>,
+    callback_reference: Ref<()>,
 }
 
 #[napi]
 impl Plugin {
     #[napi]
     pub fn transform(&self, env: Env, source_code: String) -> TransformResult {
-        let callback: JsFunction = env.get_reference_value(&self.callback).unwrap();
+        let callback: JsFunction = env.get_reference_value(&self.callback_reference).unwrap();
 
         let transform_paths = Box::new(move |path: String| {
             let args: [JsString; 1] = [env.create_string(&path).unwrap()];
@@ -42,7 +42,7 @@ impl Plugin {
 
     #[napi]
     pub fn build_end(&mut self, env: Env) -> Result<(), Error> {
-        if let Err(_) = self.callback.unref(env) {
+        if let Err(_) = self.callback_reference.unref(env) {
             return Err(Error::new(
                 napi::Status::GenericFailure,
                 String::from("Failed to cleanup callback. Unexpected Rollup lifecycle order."),
@@ -54,9 +54,19 @@ impl Plugin {
 }
 
 #[napi(ts_args_type = "callback: (path: string) => string")]
-pub fn local_import(env: Env, callback: JsFunction) -> Plugin {
-    Plugin {
+pub fn local_import(env: Env, callback: JsFunction) -> Result<Plugin, Error> {
+    let callback_reference = match env.create_reference(callback) {
+        Ok(reference) => reference,
+        Err(_) => {
+            return Err(Error::new(
+                napi::Status::GenericFailure,
+                String::from("Failed to reference callback. Did you pass function to `localImport(callback)`?"),
+            ));
+        }
+    };
+
+    Ok(Plugin {
         name: String::from("local-import"),
-        callback: env.create_reference(callback).unwrap(),
-    }
+        callback_reference,
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use napi::{Env, JsFunction, JsString, Ref};
+use napi::{Env, Error, JsFunction, JsString, Ref};
 use napi_derive::napi;
 
 mod parser;
@@ -41,8 +41,15 @@ impl Plugin {
     }
 
     #[napi]
-    pub fn build_end(&mut self, env: Env) {
-        self.callback.unref(env).unwrap();
+    pub fn build_end(&mut self, env: Env) -> Result<(), Error> {
+        if let Err(_) = self.callback.unref(env) {
+            return Err(Error::new(
+                napi::Status::GenericFailure,
+                String::from("Failed to cleanup callback. Unexpected Rollup lifecycle order."),
+            ));
+        }
+
+        Ok(())
     }
 }
 

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -1,6 +1,12 @@
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
 
 import { localImport } from "../plugin";
+
+const cleanups = [];
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
 
 test("throws useful error message when callback cleanup fails", () => {
   const plugin = localImport(() => {});
@@ -23,4 +29,15 @@ test("throws useful error message when callback is not function", () => {
   expect(() => localImport(123)).toThrowErrorMatchingInlineSnapshot(
     '"Failed to reference callback. Did you pass function to `localImport(callback)`?"'
   );
+});
+
+test.todo("throws useful error message when callback throws", () => {
+  const plugin = localImport(() => {
+    throw new Error("Error from callback");
+  });
+  cleanups.push(plugin.buildEnd);
+
+  expect(() =>
+    plugin.transform('import fs from "./some-file";')
+  ).toThrowErrorMatchingInlineSnapshot();
 });

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+
+import { localImport } from "../plugin";
+
+test("throws useful error message when callback cleanup fails", () => {
+  const plugin = localImport(() => {});
+
+  // Run cleanup once. Next one should raise error
+  plugin.buildEnd();
+
+  expect(() => plugin.buildEnd()).toThrowErrorMatchingInlineSnapshot(
+    '"Failed to cleanup callback. Unexpected Rollup lifecycle order."'
+  );
+});

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -12,3 +12,15 @@ test("throws useful error message when callback cleanup fails", () => {
     '"Failed to cleanup callback. Unexpected Rollup lifecycle order."'
   );
 });
+
+test("throws useful error message when callback is missing", () => {
+  expect(() => localImport()).toThrowErrorMatchingInlineSnapshot(
+    '"Failed to reference callback. Did you pass function to `localImport(callback)`?"'
+  );
+});
+
+test("throws useful error message when callback is not function", () => {
+  expect(() => localImport(123)).toThrowErrorMatchingInlineSnapshot(
+    '"Failed to reference callback. Did you pass function to `localImport(callback)`?"'
+  );
+});

--- a/test/rollup-integration.test.js
+++ b/test/rollup-integration.test.js
@@ -1,4 +1,4 @@
-import { rmSync, writeFileSync } from "fs";
+import { existsSync, rmSync, writeFileSync } from "fs";
 import { afterAll, expect, test } from "vitest";
 import { rollup } from "rollup";
 
@@ -8,8 +8,8 @@ const input = "input.js";
 const output = { file: "output.js" };
 
 afterAll(() => {
-  rmSync(input);
-  rmSync(output.file);
+  removeIfExists(input);
+  removeIfExists(output.file);
 });
 
 test("ExportAllDeclaration", async () => {
@@ -136,4 +136,8 @@ async function run(source) {
   const bundle = await build.write(output);
 
   return bundle.output[0].code;
+}
+
+function removeIfExists(filename) {
+  existsSync(filename) && rmSync(filename);
 }


### PR DESCRIPTION
```
feat(error-handling): callback cleanup failures
- Throw useful error message when plugin fails to cleanup callback references

feat(error-handling): callback reference failures
- Throw useful error message when callback referencing fails
```